### PR TITLE
feat: neutral pre-checkout basket and local web viewer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,11 @@
 ENVIRONMENT=test
 CROSSMINT_API_KEY=your_crossmint_api_key
 
+# Optional basket viewer configuration. Checkout credentials are not required for basket-only mode.
+CROSSMINT_BASKET_PORT=4377
+CROSSMINT_BASKET_STORE_PATH=.crossmint-agent-basket/basket.json
+# CROSSMINT_BASKET_PUBLIC_HOST=https://your-host.example.com
+
 RECIPIENT_EMAIL=your_recipient_email@example.com
 RECIPIENT_NAME=your_name
 RECIPIENT_ADDRESS_LINE1=your_address

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.npm-cache/
 
 # Environment variables
 .env
@@ -14,6 +15,9 @@ build/
 logs
 *.log
 npm-debug.log*
+
+# Local basket state
+.crossmint-agent-basket/
 
 # IDE and editor files
 .idea/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ If your agent can obtain an item SKU/identifier, this API can let it buy it.
 This MCP server takes an item identifier (from URL to SKUs) and allows you to execute a purchase of it
 in a single API call. 
 
+It also includes an agent-facing pre-checkout basket:
+- Neutral product model for any e-commerce store
+- Local JSON persistence for purchase candidates
+- MCP tools to add, review, approve, reject, and export candidates
+- A local web viewer for humans and agents to inspect the basket before any real checkout
+
 These purchases are real: 
 - The item is delivered with expedited shipping
 - A receipt is generated
@@ -109,6 +115,84 @@ Crossmint will securely transfer credits to the company wallet. The company will
     npm run crossmint-checkout
     ```
 
+## Agent Basket Viewer
+
+The basket works without Crossmint credentials. It is designed for research and pre-purchase workflows where an agent needs to collect product candidates before the user approves checkout.
+
+```bash
+npm run build
+npm run basket-viewer
+```
+
+Default URL:
+
+```text
+http://localhost:4377
+```
+
+Optional environment variables:
+
+```bash
+CROSSMINT_BASKET_PORT=4377
+CROSSMINT_BASKET_STORE_PATH=.crossmint-agent-basket/basket.json
+CROSSMINT_BASKET_PUBLIC_HOST=https://your-host.example.com
+```
+
+HTTP API:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/basket` | Compact basket summary for the viewer |
+| `GET` | `/api/basket/raw` | Full neutral basket JSON |
+| `POST` | `/api/context` | Set title, intent, buyer, locale, constraints |
+| `POST` | `/api/items` | Add or update a product candidate |
+| `POST` | `/api/items/:id/status` | Update status |
+| `DELETE` | `/api/items/:id` | Remove candidate |
+| `POST` | `/api/clear` | Clear basket with `{ "confirm": true }` |
+
+Minimal product candidate:
+
+```json
+{
+  "product": {
+    "title": "Example product",
+    "merchant": {
+      "name": "Example Store",
+      "domain": "example.com",
+      "platform": "shopify"
+    },
+    "identifiers": {
+      "sourceUrl": "https://example.com/products/example",
+      "productLocator": "shopify:https://example.com/products/example:123456"
+    },
+    "price": {
+      "current": {
+        "amount": 29.99,
+        "currency": "USD",
+        "confidence": "exact"
+      }
+    },
+    "evidence": {
+      "reason": "Matches the user request",
+      "confidence": "medium"
+    }
+  },
+  "quantity": 1,
+  "status": "candidate"
+}
+```
+
+Core neutral model areas:
+
+- Product identity: URLs, SKU, ASIN, GTIN/UPC/EAN/ISBN, variant IDs, Crossmint locator
+- Merchant: name, domain, country, platform, seller
+- Price: current/list/unit/subtotal/shipping/tax/total/discount/coupons
+- Availability: stock, limits, restock message
+- Variants and attributes: size, color, material, specs
+- Fulfillment and policy: shipping/pickup/digital, returns, warranty, restrictions
+- Agent evidence: query, sources, rationale, confidence
+- Checkout: provider, locator, support, readiness, order ID
+
 ## Use it with Claude
 
 Ask Claude to:
@@ -118,8 +202,32 @@ Ask Claude to:
 
 ## Tools
 
+### Basket tools
+
+1. `basket-set-context`
+   Sets the basket title, user intent, locale, currency, destination, target stores, and constraints.
+
+2. `basket-upsert-product`
+   Adds or updates a universal product candidate.
+
+3. `basket-list-products`
+   Lists current candidates and returns the viewer URL.
+
+4. `basket-update-status`
+   Moves a candidate through `candidate`, `shortlisted`, `needs_review`, `approved`, `ready_for_checkout`, `ordered`, or `rejected`.
+
+5. `basket-export-crossmint-line-items`
+   Exports approved/ready candidates with Crossmint-compatible locators.
+
+6. `basket-get-viewer`
+   Returns viewer URL, store path, and HTTP API endpoints.
+
+### Checkout tools
+
 1. `create-order`
    Creates a new order for a specified product. Amazon products are specified as 'amazon:<amazon_product_id>' or 'amazon:<asin>', while Shopify products as 'shopify:<product-url>:<variant-id>'.
+
+   This performs a real checkout when Crossmint credentials and wallet env vars are configured.
 
    Example Prompt:
    > "Buy me this https://www.amazon.com/Sparkling-Naturally-Essenced-Calories-Sweeteners/dp/B00O79SKV6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "1.25.0",
         "dotenv": "^16.4.5",
         "viem": "^2.30.0",
-        "zod": "^3.24.3"
+        "zod": "3.25.23"
       },
       "bin": {
+        "crossmint-basket-viewer": "build/viewer.js",
         "crossmint-checkout": "build/index.js"
       },
       "devDependencies": {
@@ -41,12 +42,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.0.tgz",
+      "integrity": "sha512-z0Zhn/LmQ3yz91dEfd5QgS7DpSjA4pk+3z2++zKgn5L6iDFM9QapsVoAQSbKLvlrFsZk9+ru6yHHWNq2lCYJKQ==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -54,15 +55,14 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod-to-json-schema": "^3.25.0"
       },
       "engines": {
         "node": ">=18"
@@ -78,6 +78,24 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@noble/curves": {
@@ -221,21 +239,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -283,9 +314,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -435,9 +466,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -532,13 +563,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.0.1"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -681,9 +709,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -697,6 +725,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -742,15 +771,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -969,9 +989,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1001,9 +1021,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1143,14 +1163,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1162,13 +1182,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1233,17 +1253,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -1364,15 +1401,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "crossmint-checkout": "./build/index.js"
+    "crossmint-checkout": "./build/index.js",
+    "crossmint-basket-viewer": "./build/viewer.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && chmod 755 build/index.js",
+    "build": "tsc && chmod 755 build/index.js build/viewer.js",
     "crossmint-checkout": "node ./build/index.js",
+    "basket-viewer": "node ./build/viewer.js",
+    "dev:basket-viewer": "npm run build && node ./build/viewer.js",
     "generate-agent-wallet": "node scripts/generate-agent-wallet.js",
     "update-claude-config": "node scripts/update-claude-config.js",
     "transfer-credits": "node scripts/transfer-credits.js $1 $2"
@@ -27,10 +30,10 @@
   "license": "ISC",
   "description": "Model Context Protocol server for Crossmint Checkout",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "1.25.0",
     "dotenv": "^16.4.5",
     "viem": "^2.30.0",
-    "zod": "^3.24.3"
+    "zod": "3.25.23"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",

--- a/src/basket/schema.ts
+++ b/src/basket/schema.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+
+export const CandidateStatusSchema = z.enum([
+  "candidate",
+  "shortlisted",
+  "needs_review",
+  "approved",
+  "ready_for_checkout",
+  "ordered",
+  "rejected",
+]);
+
+const FlexibleRecordSchema = z.record(z.unknown());
+const UrlRecordSchema = z.record(z.string().url());
+
+export const ProductSnapshotSchema = z.object({
+  title: z.string().min(1).describe("Human-readable product title."),
+  subtitle: z.string().optional(),
+  description: z.string().optional(),
+  brand: z.string().optional(),
+  category: z.string().optional(),
+  condition: z.enum(["new", "used", "refurbished", "open_box", "unknown"]).optional(),
+  merchant: FlexibleRecordSchema.optional().describe("Store, platform, seller, country, and domain metadata."),
+  identifiers: z.record(z.string().optional()).optional().describe("URLs, SKU, ASIN, GTIN, UPC, variant IDs, productLocator, crossmintLocator."),
+  urls: UrlRecordSchema.optional().describe("Product, canonical, checkout, image, and affiliate URLs."),
+  images: z.array(z.object({
+    url: z.string().url(),
+    type: z.enum(["image", "video", "thumbnail"]).optional(),
+    alt: z.string().optional(),
+  }).passthrough()).optional(),
+  selectedOptions: z.array(FlexibleRecordSchema).optional().describe("Selected variant options such as size, color, storage, delivery plan."),
+  attributes: z.array(FlexibleRecordSchema).optional().describe("Structured product specs and attributes."),
+  price: FlexibleRecordSchema.optional().describe("current, list, unit, subtotal, shipping, taxEstimate, totalEstimate, discount, coupons."),
+  availability: FlexibleRecordSchema.optional().describe("Stock status, limits, restock date, and store message."),
+  fulfillment: FlexibleRecordSchema.optional().describe("Shipping, pickup, digital delivery, destination, speed, carrier."),
+  policy: FlexibleRecordSchema.optional().describe("Returns, warranty, restrictions, subscription terms, compliance notes."),
+  rating: FlexibleRecordSchema.optional().describe("Rating value, scale, count, review summary."),
+  evidence: FlexibleRecordSchema.optional().describe("Query, reason, confidence, sources, observed timestamps."),
+}).passthrough();
+
+export const CheckoutSchema = z.object({
+  provider: z.enum(["crossmint", "merchant", "manual", "unknown"]).optional(),
+  locator: z.string().optional().describe("Provider-specific checkout locator."),
+  supported: z.boolean().optional(),
+  readiness: z.enum(["missing_locator", "needs_validation", "ready", "blocked", "unknown"]).optional(),
+  orderId: z.string().optional(),
+  lastCheckedAt: z.string().optional(),
+  notes: z.string().optional(),
+}).passthrough();
+
+export const CandidateDecisionSchema = z.object({
+  rank: z.number().int().positive().optional(),
+  score: z.number().min(0).max(1).optional(),
+  rationale: z.string().optional(),
+  tradeoffs: z.array(z.string()).optional(),
+}).passthrough();
+
+export const CartItemSchema = z.object({
+  id: z.string(),
+  status: CandidateStatusSchema.default("candidate"),
+  quantity: z.number().int().positive().default(1),
+  product: ProductSnapshotSchema,
+  checkout: CheckoutSchema.optional(),
+  decision: CandidateDecisionSchema.optional(),
+  notes: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  comparisonGroupId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  extra: FlexibleRecordSchema.optional(),
+}).passthrough();
+
+export const CartItemInputSchema = z.object({
+  id: z.string().optional(),
+  status: CandidateStatusSchema.optional(),
+  quantity: z.number().int().positive().optional(),
+  product: ProductSnapshotSchema,
+  checkout: CheckoutSchema.optional(),
+  decision: CandidateDecisionSchema.optional(),
+  notes: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  comparisonGroupId: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  extra: FlexibleRecordSchema.optional(),
+}).passthrough();
+
+export const BasketContextSchema = z.object({
+  title: z.string().optional(),
+  intent: z.string().optional().describe("User shopping/research intent."),
+  buyer: z.string().optional(),
+  locale: z.string().optional(),
+  currency: z.string().min(3).max(3).optional(),
+  destinationCountry: z.string().optional(),
+  constraints: z.array(z.string()).optional(),
+  targetStores: z.array(z.string()).optional(),
+}).passthrough();
+
+export const BasketSchema = z.object({
+  version: z.literal(1).default(1),
+  id: z.string(),
+  context: BasketContextSchema.default({}),
+  items: z.array(CartItemSchema).default([]),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}).passthrough();
+
+export const BasketContextInputSchema = BasketContextSchema.extend({
+  resetMissingFields: z.boolean().optional(),
+}).passthrough();
+
+export type CandidateStatus =
+  | "candidate"
+  | "shortlisted"
+  | "needs_review"
+  | "approved"
+  | "ready_for_checkout"
+  | "ordered"
+  | "rejected";
+
+export type Money = Record<string, unknown> & {
+  amount?: number;
+  currency?: string;
+  display?: string;
+};
+
+export type ProductSnapshot = Record<string, unknown> & {
+  title: string;
+  brand?: string;
+  merchant?: Record<string, unknown>;
+  identifiers?: Record<string, string | undefined>;
+  urls?: Record<string, string | undefined>;
+  images?: Array<Record<string, unknown> & { url: string }>;
+  price?: Record<string, Money | unknown>;
+  availability?: Record<string, unknown> & { status?: string };
+  evidence?: Record<string, unknown> & {
+    reason?: string;
+    confidence?: string;
+  };
+};
+
+export type CheckoutState = Record<string, unknown> & {
+  provider?: "crossmint" | "merchant" | "manual" | "unknown";
+  locator?: string;
+  supported?: boolean;
+  readiness?: "missing_locator" | "needs_validation" | "ready" | "blocked" | "unknown";
+  orderId?: string;
+};
+
+export type CartItem = Record<string, unknown> & {
+  id: string;
+  status: CandidateStatus;
+  quantity: number;
+  product: ProductSnapshot;
+  checkout?: CheckoutState;
+  notes?: string;
+  tags?: string[];
+  comparisonGroupId?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CartItemInput = Record<string, unknown> & {
+  id?: string;
+  status?: CandidateStatus;
+  quantity?: number;
+  product: ProductSnapshot;
+  checkout?: CheckoutState;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type Basket = Record<string, unknown> & {
+  version: 1;
+  id: string;
+  context: Record<string, unknown> & {
+    title?: string;
+    intent?: string;
+    currency?: string;
+  };
+  items: CartItem[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BasketContextInput = Record<string, unknown> & {
+  title?: string;
+  intent?: string;
+  buyer?: string;
+  locale?: string;
+  currency?: string;
+  destinationCountry?: string;
+  constraints?: string[];
+  targetStores?: string[];
+  resetMissingFields?: boolean;
+};
+
+export const BASKET_MODEL_FIELD_GUIDE = [
+  "product.title, brand, category, condition, description",
+  "product.merchant.name, domain, url, platform, sellerName",
+  "product.identifiers.sourceUrl, canonicalUrl, sku, asin, gtin, variantId, productLocator",
+  "product.price.current, list, discount, shipping, taxEstimate, totalEstimate",
+  "product.availability.status, quantityAvailable, limitPerCustomer",
+  "product.selectedOptions for size/color/storage/etc.",
+  "product.fulfillment for shipping, pickup, digital delivery, and destination constraints",
+  "product.policy for returns, warranty, restrictions, subscription terms",
+  "product.evidence for query, sources, confidence, and why it matches the user intent",
+  "checkout.provider, locator, supported, readiness before any real purchase",
+];

--- a/src/basket/store.ts
+++ b/src/basket/store.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  BasketContextInput,
+  BasketContextInputSchema,
+  Basket,
+  BasketSchema,
+  CandidateStatus,
+  CandidateStatusSchema,
+  CartItem,
+  CartItemInput,
+  CartItemInputSchema,
+} from "./schema.js";
+
+const DEFAULT_BASKET_DIR = ".crossmint-agent-basket";
+const DEFAULT_BASKET_FILE = "basket.json";
+
+type CompactMoney = {
+  amount?: number;
+  currency?: string;
+  display?: string;
+};
+
+export function resolveBasketStorePath(): string {
+  return path.resolve(
+    process.env.CROSSMINT_BASKET_STORE_PATH ||
+      path.join(process.cwd(), DEFAULT_BASKET_DIR, DEFAULT_BASKET_FILE)
+  );
+}
+
+export function resolveBasketViewerPort(): number {
+  const raw = process.env.CROSSMINT_BASKET_PORT || process.env.PORT || "4377";
+  const port = Number.parseInt(raw, 10);
+  return Number.isFinite(port) && port > 0 ? port : 4377;
+}
+
+export function getBasketViewerUrl(port = resolveBasketViewerPort()): string {
+  const host = process.env.CROSSMINT_BASKET_PUBLIC_HOST || `http://localhost:${port}`;
+  return host.replace(/\/$/, "");
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function defaultBasket(): Basket {
+  const now = nowIso();
+  return {
+    version: 1,
+    id: "default",
+    context: {},
+    items: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function checkoutLocatorFor(item: Pick<CartItem, "product" | "checkout">): string | undefined {
+  return (
+    item.checkout?.locator ||
+    item.product.identifiers?.crossmintLocator ||
+    item.product.identifiers?.productLocator
+  );
+}
+
+function normalizeCheckout(input: CartItemInput, existing?: CartItem): CartItem["checkout"] {
+  const locator =
+    input.checkout?.locator ||
+    input.product.identifiers?.crossmintLocator ||
+    input.product.identifiers?.productLocator ||
+    existing?.checkout?.locator;
+
+  const supportedByLocator = locator?.startsWith("amazon:") || locator?.startsWith("shopify:");
+
+  return {
+    ...existing?.checkout,
+    ...input.checkout,
+    provider: input.checkout?.provider || existing?.checkout?.provider || (locator ? "crossmint" : "unknown"),
+    locator,
+    supported: input.checkout?.supported ?? existing?.checkout?.supported ?? supportedByLocator ?? undefined,
+    readiness:
+      input.checkout?.readiness ||
+      existing?.checkout?.readiness ||
+      (locator ? "needs_validation" : "missing_locator"),
+  };
+}
+
+function normalizeItem(input: CartItemInput, existing?: CartItem): CartItem {
+  const parsed = CartItemInputSchema.parse(input) as CartItemInput;
+  const createdAt = existing?.createdAt || parsed.createdAt || nowIso();
+
+  return {
+    ...existing,
+    ...parsed,
+    id: parsed.id || existing?.id || randomUUID(),
+    status: parsed.status || existing?.status || "candidate",
+    quantity: parsed.quantity || existing?.quantity || 1,
+    product: parsed.product,
+    checkout: normalizeCheckout(parsed, existing),
+    createdAt,
+    updatedAt: nowIso(),
+  };
+}
+
+function compactItem(item: CartItem) {
+  const price = moneyFrom(item.product.price?.current || item.product.price?.totalEstimate);
+  return {
+    id: item.id,
+    status: item.status,
+    quantity: item.quantity,
+    title: item.product.title,
+    brand: item.product.brand,
+    merchant: item.product.merchant,
+    url: item.product.urls?.product || item.product.identifiers?.sourceUrl,
+    image: item.product.images?.[0]?.url || item.product.urls?.image,
+    price,
+    availability: item.product.availability?.status,
+    locator: checkoutLocatorFor(item),
+    checkout: item.checkout,
+    reason: item.product.evidence?.reason,
+    confidence: item.product.evidence?.confidence,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function moneyFrom(value: unknown): CompactMoney | undefined {
+  return value != null && typeof value === "object" ? value as CompactMoney : undefined;
+}
+
+export function summarizeBasket(basket: Basket) {
+  const statuses = basket.items.reduce<Record<string, number>>((acc, item) => {
+    acc[item.status] = (acc[item.status] || 0) + 1;
+    return acc;
+  }, {});
+
+  const totalsByCurrency = basket.items.reduce<Record<string, number>>((acc, item) => {
+    const money = moneyFrom(item.product.price?.totalEstimate || item.product.price?.current);
+    if (money?.amount == null) {
+      return acc;
+    }
+    const currency = money.currency || basket.context.currency || "USD";
+    acc[currency] = (acc[currency] || 0) + money.amount * item.quantity;
+    return acc;
+  }, {});
+
+  const checkoutReady = basket.items.filter((item) => {
+    const statusReady = item.status === "approved" || item.status === "ready_for_checkout";
+    return statusReady && checkoutLocatorFor(item) != null;
+  }).length;
+
+  return {
+    id: basket.id,
+    context: basket.context,
+    itemCount: basket.items.length,
+    statuses,
+    checkoutReady,
+    missingCheckoutLocator: basket.items.filter((item) => checkoutLocatorFor(item) == null).length,
+    totalsByCurrency,
+    updatedAt: basket.updatedAt,
+    items: basket.items.map(compactItem),
+  };
+}
+
+export class BasketStore {
+  constructor(private readonly filePath = resolveBasketStorePath()) {}
+
+  path(): string {
+    return this.filePath;
+  }
+
+  async load(): Promise<Basket> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      const json = JSON.parse(raw);
+      return BasketSchema.parse(json) as Basket;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        const basket = defaultBasket();
+        await this.save(basket);
+        return basket;
+      }
+      throw error;
+    }
+  }
+
+  async save(basket: Basket): Promise<Basket> {
+    const parsed = BasketSchema.parse({
+      ...basket,
+      updatedAt: nowIso(),
+    }) as Basket;
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    const tmpPath = `${this.filePath}.${process.pid}.tmp`;
+    await writeFile(tmpPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+    await rename(tmpPath, this.filePath);
+    return parsed;
+  }
+
+  async setContext(input: BasketContextInput): Promise<Basket> {
+    const parsed = BasketContextInputSchema.parse(input) as BasketContextInput;
+    const { resetMissingFields, ...context } = parsed;
+    const basket = await this.load();
+    return this.save({
+      ...basket,
+      context: resetMissingFields ? context : { ...basket.context, ...context },
+    });
+  }
+
+  async upsertItem(input: CartItemInput): Promise<{ basket: Basket; item: CartItem; created: boolean }> {
+    const basket = await this.load();
+    const index = input.id ? basket.items.findIndex((item) => item.id === input.id) : -1;
+    const existing = index >= 0 ? basket.items[index] : undefined;
+    const item = normalizeItem(input, existing);
+    const items = [...basket.items];
+
+    if (index >= 0) {
+      items[index] = item;
+    } else {
+      items.push(item);
+    }
+
+    const saved = await this.save({ ...basket, items });
+    return { basket: saved, item, created: index < 0 };
+  }
+
+  async updateStatus(id: string, status: CandidateStatus): Promise<CartItem | null> {
+    const parsedStatus = CandidateStatusSchema.parse(status) as CandidateStatus;
+    const basket = await this.load();
+    const item = basket.items.find((candidate) => candidate.id === id);
+    if (item == null) {
+      return null;
+    }
+    item.status = parsedStatus;
+    item.updatedAt = nowIso();
+    await this.save(basket);
+    return item;
+  }
+
+  async removeItem(id: string): Promise<boolean> {
+    const basket = await this.load();
+    const nextItems = basket.items.filter((item) => item.id !== id);
+    if (nextItems.length === basket.items.length) {
+      return false;
+    }
+    await this.save({ ...basket, items: nextItems });
+    return true;
+  }
+
+  async clear(): Promise<Basket> {
+    const basket = await this.load();
+    return this.save({ ...basket, items: [] });
+  }
+
+  async exportCrossmintLineItems(itemIds?: string[]) {
+    const basket = await this.load();
+    const selected = basket.items.filter((item) => {
+      const selectedById = itemIds == null || itemIds.length === 0 || itemIds.includes(item.id);
+      const selectedByStatus = item.status === "approved" || item.status === "ready_for_checkout";
+      return selectedById && selectedByStatus;
+    });
+
+    const lineItems = selected.flatMap((item) => {
+      const locator = checkoutLocatorFor(item);
+      return locator == null ? [] : [{ productLocator: locator, quantity: item.quantity }];
+    });
+
+    const missing = selected.filter((item) => checkoutLocatorFor(item) == null).map((item) => ({
+      id: item.id,
+      title: item.product.title,
+      reason: "Missing checkout locator",
+    }));
+
+    return {
+      lineItems,
+      missing,
+      selected: selected.map(compactItem),
+    };
+  }
+}

--- a/src/basket/viewer-html.ts
+++ b/src/basket/viewer-html.ts
@@ -1,0 +1,490 @@
+import { BASKET_MODEL_FIELD_GUIDE } from "./schema.js";
+
+function safeJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+export function renderBasketViewerHtml(): string {
+  const modelFields = safeJson(BASKET_MODEL_FIELD_GUIDE);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Basket</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f3;
+      --surface: #ffffff;
+      --ink: #17201b;
+      --muted: #66716b;
+      --line: #d9dfd7;
+      --green: #146b4a;
+      --green-ink: #effaf3;
+      --blue: #2c5f9e;
+      --amber: #9b6515;
+      --red: #9f2d2d;
+      --shadow: 0 14px 40px rgba(20, 31, 26, 0.08);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    button, input, select { font: inherit; }
+
+    .app {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      min-height: 100vh;
+    }
+
+    main {
+      padding: 28px;
+      min-width: 0;
+    }
+
+    aside {
+      border-left: 1px solid var(--line);
+      background: #fbfcf8;
+      padding: 24px;
+      min-width: 0;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 22px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 30px;
+      line-height: 1.1;
+      font-weight: 750;
+    }
+
+    .intent {
+      margin: 8px 0 0;
+      color: var(--muted);
+      max-width: 840px;
+      line-height: 1.45;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      flex-shrink: 0;
+    }
+
+    .icon-button {
+      width: 38px;
+      height: 38px;
+      border-radius: 7px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--ink);
+      cursor: pointer;
+      box-shadow: 0 1px 1px rgba(0,0,0,0.03);
+    }
+
+    .icon-button:hover { border-color: #aeb8af; }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(130px, 1fr));
+      gap: 12px;
+      margin-bottom: 22px;
+    }
+
+    .stat {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px 16px;
+      box-shadow: 0 1px 1px rgba(0,0,0,0.02);
+      min-height: 80px;
+    }
+
+    .stat span {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    .stat strong {
+      display: block;
+      margin-top: 8px;
+      font-size: 24px;
+      line-height: 1;
+    }
+
+    .items {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 14px;
+    }
+
+    .item {
+      display: grid;
+      grid-template-columns: 112px minmax(0, 1fr);
+      gap: 14px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      min-height: 168px;
+      box-shadow: var(--shadow);
+    }
+
+    .thumb {
+      width: 112px;
+      height: 144px;
+      border-radius: 7px;
+      background: #e8ece5;
+      border: 1px solid #d1d8d0;
+      overflow: hidden;
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .item-body {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .item-title {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.25;
+      font-weight: 720;
+      overflow-wrap: anywhere;
+    }
+
+    .meta, .reason, .locator {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .price-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .price {
+      font-size: 18px;
+      font-weight: 760;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      height: 24px;
+      border-radius: 999px;
+      padding: 0 9px;
+      font-size: 12px;
+      border: 1px solid var(--line);
+      background: #f8faf6;
+      color: var(--muted);
+      max-width: 100%;
+    }
+
+    .pill.ready { background: #e8f5ee; color: var(--green); border-color: #b8ddc9; }
+    .pill.review { background: #fff6df; color: var(--amber); border-color: #efd18b; }
+    .pill.rejected { background: #fdeeee; color: var(--red); border-color: #e5b7b7; }
+
+    .item-controls {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 6px;
+      margin-top: auto;
+    }
+
+    .item-controls button {
+      height: 32px;
+      border: 1px solid var(--line);
+      background: #fbfcf9;
+      border-radius: 7px;
+      cursor: pointer;
+      color: var(--ink);
+      font-size: 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .item-controls button:hover { border-color: #aeb8af; }
+
+    .item-controls .primary {
+      background: var(--green);
+      color: var(--green-ink);
+      border-color: var(--green);
+    }
+
+    .panel-title {
+      margin: 0 0 14px;
+      font-size: 14px;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .model-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 0 0 26px;
+      padding: 0;
+      list-style: none;
+    }
+
+    .model-list li {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 7px 10px;
+      background: var(--surface);
+      color: var(--muted);
+      font-size: 12px;
+      max-width: 100%;
+      overflow-wrap: anywhere;
+    }
+
+    .status-table {
+      display: grid;
+      gap: 8px;
+    }
+
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      border-bottom: 1px solid var(--line);
+      padding: 9px 0;
+      color: var(--muted);
+    }
+
+    .status-row strong { color: var(--ink); }
+
+    .empty {
+      border: 1px dashed #bcc7bd;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.55);
+      padding: 34px;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    @media (max-width: 980px) {
+      .app { grid-template-columns: 1fr; }
+      aside { border-left: 0; border-top: 1px solid var(--line); }
+      .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    @media (max-width: 620px) {
+      main, aside { padding: 18px; }
+      .topbar { flex-direction: column; }
+      .stats { grid-template-columns: 1fr; }
+      .items { grid-template-columns: 1fr; }
+      .item { grid-template-columns: 92px minmax(0, 1fr); }
+      .thumb { width: 92px; height: 124px; }
+      .item-controls { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <main>
+      <header class="topbar">
+        <div>
+          <h1 id="title">Agent Basket</h1>
+          <p class="intent" id="intent"></p>
+        </div>
+        <div class="actions">
+          <button class="icon-button" id="refresh" title="Refresh" aria-label="Refresh">R</button>
+        </div>
+      </header>
+
+      <section class="stats" aria-label="Basket stats">
+        <div class="stat"><span>Items</span><strong id="stat-items">0</strong></div>
+        <div class="stat"><span>Ready</span><strong id="stat-ready">0</strong></div>
+        <div class="stat"><span>Missing locator</span><strong id="stat-missing">0</strong></div>
+        <div class="stat"><span>Total</span><strong id="stat-total">-</strong></div>
+      </section>
+
+      <section class="items" id="items"></section>
+    </main>
+
+    <aside>
+      <h2 class="panel-title">Model</h2>
+      <ul class="model-list" id="model-list"></ul>
+
+      <h2 class="panel-title">Statuses</h2>
+      <div class="status-table" id="status-table"></div>
+    </aside>
+  </div>
+
+  <script>
+    window.MODEL_FIELDS = ${modelFields};
+
+    const state = { basket: null };
+
+    function text(value, fallback) {
+      return value == null || value === '' ? fallback : value;
+    }
+
+    function money(value) {
+      if (!value) return '-';
+      if (value.display) return value.display;
+      if (value.amount == null) return '-';
+      try {
+        return new Intl.NumberFormat(undefined, {
+          style: 'currency',
+          currency: value.currency || 'USD'
+        }).format(value.amount);
+      } catch {
+        return String(value.amount) + ' ' + (value.currency || '');
+      }
+    }
+
+    function statusClass(status) {
+      if (status === 'approved' || status === 'ready_for_checkout' || status === 'ordered') return 'ready';
+      if (status === 'needs_review' || status === 'shortlisted') return 'review';
+      if (status === 'rejected') return 'rejected';
+      return '';
+    }
+
+    function totalText(totals) {
+      const entries = Object.entries(totals || {});
+      if (entries.length === 0) return '-';
+      return entries.map(function(entry) {
+        return money({ amount: entry[1], currency: entry[0] });
+      }).join(' + ');
+    }
+
+    function renderModel() {
+      const list = document.getElementById('model-list');
+      list.innerHTML = window.MODEL_FIELDS.map(function(field) {
+        return '<li>' + field.replace(/^product\\./, '') + '</li>';
+      }).join('');
+    }
+
+    function renderStatuses(basket) {
+      const table = document.getElementById('status-table');
+      const statuses = basket.statuses || {};
+      const entries = Object.keys(statuses).sort().map(function(key) {
+        return '<div class="status-row"><span>' + key + '</span><strong>' + statuses[key] + '</strong></div>';
+      });
+      table.innerHTML = entries.length === 0 ? '<div class="status-row"><span>empty</span><strong>0</strong></div>' : entries.join('');
+    }
+
+    function renderItem(item) {
+      const merchant = item.merchant && (item.merchant.name || item.merchant.domain) ? (item.merchant.name || item.merchant.domain) : 'Unknown merchant';
+      const readiness = item.checkout && item.checkout.readiness ? item.checkout.readiness : 'unknown';
+      const image = item.image ? '<img src="' + item.image + '" alt="">' : 'No image';
+      const sourceLink = item.url ? '<a href="' + item.url + '" target="_blank" rel="noreferrer">' + merchant + '</a>' : merchant;
+      return [
+        '<article class="item" data-id="' + item.id + '">',
+          '<div class="thumb">' + image + '</div>',
+          '<div class="item-body">',
+            '<h3 class="item-title">' + text(item.title, 'Untitled product') + '</h3>',
+            '<p class="meta">' + sourceLink + ' · Qty ' + item.quantity + '</p>',
+            '<div class="price-row">',
+              '<span class="price">' + money(item.price) + '</span>',
+              '<span class="pill ' + statusClass(item.status) + '">' + item.status + '</span>',
+              '<span class="pill">' + readiness + '</span>',
+            '</div>',
+            '<p class="reason">' + text(item.reason, 'No rationale captured yet.') + '</p>',
+            '<p class="locator">' + text(item.locator, 'No checkout locator') + '</p>',
+            '<div class="item-controls">',
+              '<button data-action="status" data-status="candidate">Candidate</button>',
+              '<button data-action="status" data-status="shortlisted">Shortlist</button>',
+              '<button class="primary" data-action="status" data-status="approved">Approve</button>',
+              '<button data-action="status" data-status="rejected">Reject</button>',
+            '</div>',
+          '</div>',
+        '</article>'
+      ].join('');
+    }
+
+    function render(basket) {
+      state.basket = basket;
+      const context = basket.context || {};
+      document.getElementById('title').textContent = context.title || 'Agent Basket';
+      document.getElementById('intent').textContent = context.intent || 'Neutral pre-checkout workspace for purchase candidates.';
+      document.getElementById('stat-items').textContent = basket.itemCount || 0;
+      document.getElementById('stat-ready').textContent = basket.checkoutReady || 0;
+      document.getElementById('stat-missing').textContent = basket.missingCheckoutLocator || 0;
+      document.getElementById('stat-total').textContent = totalText(basket.totalsByCurrency);
+      const items = document.getElementById('items');
+      items.innerHTML = basket.items && basket.items.length
+        ? basket.items.map(renderItem).join('')
+        : '<div class="empty">No products in the basket.</div>';
+      renderStatuses(basket);
+    }
+
+    async function loadBasket() {
+      const response = await fetch('/api/basket', { cache: 'no-store' });
+      if (!response.ok) throw new Error('Failed to load basket');
+      render(await response.json());
+    }
+
+    async function updateStatus(id, status) {
+      const response = await fetch('/api/items/' + encodeURIComponent(id) + '/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: status })
+      });
+      if (!response.ok) throw new Error('Failed to update status');
+      await loadBasket();
+    }
+
+    document.addEventListener('click', function(event) {
+      const button = event.target.closest('button');
+      if (!button) return;
+      if (button.id === 'refresh') {
+        loadBasket();
+        return;
+      }
+      const action = button.getAttribute('data-action');
+      if (action === 'status') {
+        const item = button.closest('.item');
+        updateStatus(item.getAttribute('data-id'), button.getAttribute('data-status'));
+      }
+    });
+
+    renderModel();
+    loadBasket();
+    setInterval(loadBasket, 5000);
+  </script>
+</body>
+</html>`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,22 @@
+#!/usr/bin/env node
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import dotenv from "dotenv";
+import {
+  BasketStore,
+  getBasketViewerUrl,
+  resolveBasketStorePath,
+  resolveBasketViewerPort,
+  summarizeBasket,
+} from "./basket/store.js";
+import {
+  BASKET_MODEL_FIELD_GUIDE,
+  BasketContextInputSchema,
+  CandidateStatusSchema,
+  CartItemInputSchema,
+} from "./basket/schema.js";
 
 dotenv.config();
 
@@ -12,16 +27,40 @@ const CROSSMINT_API_BASE = isProduction
 const CHAIN = isProduction ? 'ethereum' : 'ethereum-sepolia';
 const TOKEN = 'credit';
 const USER_AGENT = "crossmint-checkout/1.0";
+const basketStore = new BasketStore();
+const basketContextToolShape = BasketContextInputSchema.shape as Record<string, z.ZodTypeAny>;
+const cartItemInputToolSchema = (CartItemInputSchema as z.ZodTypeAny)
+  .describe("Universal cart product candidate with product, price, merchant, evidence, and checkout fields.");
+const candidateStatusToolSchema = CandidateStatusSchema as z.ZodTypeAny;
 
 // Create server instance
 const server = new McpServer({
   name: "crossmint-checkout",
   version: "1.0.0",
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
 });
+const registerTool = server.tool.bind(server) as (...args: any[]) => void;
+
+function textResponse(value: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: typeof value === "string" ? value : JSON.stringify(value, null, 2),
+      },
+    ],
+  };
+}
+
+function missingCheckoutConfig(): string[] {
+  const missing = [];
+  if (!process.env.CROSSMINT_API_KEY) {
+    missing.push("CROSSMINT_API_KEY");
+  }
+  if (!process.env.AGENT_WALLET_ADDRESS) {
+    missing.push("AGENT_WALLET_ADDRESS");
+  }
+  return missing;
+}
 
 // Helper function for making Crossmint API requests
 async function makeCrossmintRequest(
@@ -96,8 +135,139 @@ async function createTransaction(serializedTx: string): Promise<string | null> {
   }
 }
 
+registerTool(
+  "basket-set-context",
+  "Set shopping or research context for the neutral pre-checkout basket",
+  basketContextToolShape,
+  async (input: any) => {
+    const basket = await basketStore.setContext(input);
+    return textResponse({
+      basket: summarizeBasket(basket),
+      storePath: basketStore.path(),
+      viewerUrl: getBasketViewerUrl(),
+    });
+  }
+);
+
+registerTool(
+  "basket-upsert-product",
+  "Add or update a product candidate in the neutral pre-checkout basket",
+  {
+    item: cartItemInputToolSchema,
+  },
+  async ({ item }: any) => {
+    const result = await basketStore.upsertItem(item);
+    return textResponse({
+      created: result.created,
+      item: result.item,
+      basket: summarizeBasket(result.basket),
+      viewerUrl: getBasketViewerUrl(),
+    });
+  }
+);
+
+registerTool(
+  "basket-list-products",
+  "List product candidates currently stored in the pre-checkout basket",
+  {
+    includeRaw: z.boolean().optional().describe("Return full raw basket data instead of compact UI summary."),
+  },
+  async ({ includeRaw }: any) => {
+    const basket = await basketStore.load();
+    return textResponse({
+      basket: includeRaw ? basket : summarizeBasket(basket),
+      storePath: basketStore.path(),
+      viewerUrl: getBasketViewerUrl(),
+      modelFields: includeRaw ? BASKET_MODEL_FIELD_GUIDE : undefined,
+    });
+  }
+);
+
+registerTool(
+  "basket-update-status",
+  "Update a product candidate status without changing the product snapshot",
+  {
+    id: z.string().describe("Basket item id."),
+    status: candidateStatusToolSchema.describe("New candidate status."),
+  },
+  async ({ id, status }: any) => {
+    const item = await basketStore.updateStatus(id, status);
+    if (item == null) {
+      return textResponse({ error: "Item not found", id });
+    }
+    return textResponse({
+      item,
+      basket: summarizeBasket(await basketStore.load()),
+      viewerUrl: getBasketViewerUrl(),
+    });
+  }
+);
+
+registerTool(
+  "basket-remove-product",
+  "Remove a product candidate from the pre-checkout basket",
+  {
+    id: z.string().describe("Basket item id."),
+  },
+  async ({ id }: any) => {
+    const removed = await basketStore.removeItem(id);
+    return textResponse({
+      removed,
+      basket: summarizeBasket(await basketStore.load()),
+      viewerUrl: getBasketViewerUrl(),
+    });
+  }
+);
+
+registerTool(
+  "basket-clear",
+  "Clear all product candidates from the pre-checkout basket",
+  {
+    confirm: z.boolean().describe("Must be true to clear the basket."),
+  },
+  async ({ confirm }: any) => {
+    if (confirm !== true) {
+      return textResponse({ error: "confirm must be true" });
+    }
+    return textResponse({
+      basket: summarizeBasket(await basketStore.clear()),
+      viewerUrl: getBasketViewerUrl(),
+    });
+  }
+);
+
+registerTool(
+  "basket-get-viewer",
+  "Return the local basket viewer URL, store path, and startup command",
+  {},
+  async () => {
+    const port = resolveBasketViewerPort();
+    return textResponse({
+      viewerUrl: getBasketViewerUrl(port),
+      storePath: resolveBasketStorePath(),
+      command: "npm run basket-viewer",
+      api: {
+        basket: `${getBasketViewerUrl(port)}/api/basket`,
+        rawBasket: `${getBasketViewerUrl(port)}/api/basket/raw`,
+        addItem: `${getBasketViewerUrl(port)}/api/items`,
+      },
+    });
+  }
+);
+
+registerTool(
+  "basket-export-crossmint-line-items",
+  "Export approved basket candidates as Crossmint create-order lineItems when locators are available",
+  {
+    itemIds: z.array(z.string()).optional().describe("Optional list of basket item ids. Defaults to approved or ready_for_checkout items."),
+  },
+  async ({ itemIds }: any) => {
+    return textResponse(await basketStore.exportCrossmintLineItems(itemIds));
+  }
+);
+
 // Register crossmint checkout tool to create orders
-server.tool(
+registerTool(
   "create-order",
   "Create a new order for a product",
   {
@@ -110,9 +280,17 @@ server.tool(
   },
   async ({
     lineItems
-  }) => {
+  }: any) => {
 
     try {
+      const missing = missingCheckoutConfig();
+      if (missing.length > 0) {
+        return textResponse({
+          error: "Crossmint checkout is not configured. Basket tools still work.",
+          missingEnv: missing,
+        });
+      }
+
       const envRecipient = {
         email: process.env.RECIPIENT_EMAIL,
         physicalAddress: {
@@ -167,14 +345,21 @@ server.tool(
 );
 
 
-server.tool(
+registerTool(
   "check-order",
   "Check the status of an existing order",
   {
     orderId: z.string().describe("The order ID to check"),
   },
-  async ({ orderId }) => {
+  async ({ orderId }: any) => {
     try {
+      if (!process.env.CROSSMINT_API_KEY) {
+        return textResponse({
+          error: "Crossmint checkout is not configured.",
+          missingEnv: ["CROSSMINT_API_KEY"],
+        });
+      }
+
       const response = await makeCrossmintRequest(`/orders/${orderId}`);
 
       return {
@@ -200,12 +385,20 @@ server.tool(
 );
 
 // Get balance tool
-server.tool(
+registerTool(
   "get-usd-balance",
   "Get the USD balance of the wallet",
   {},
   async () => {
     try {
+      const missing = missingCheckoutConfig();
+      if (missing.length > 0) {
+        return textResponse({
+          error: "Crossmint checkout is not configured.",
+          missingEnv: missing,
+        });
+      }
+
       const address = process.env.AGENT_WALLET_ADDRESS;
 
       const response = await fetch(
@@ -244,14 +437,6 @@ server.tool(
 );
 
 async function main() {
-  if (!process.env.CROSSMINT_API_KEY) {
-    process.exit(1);
-  }
-
-  if (!process.env.AGENT_WALLET_ADDRESS) {
-    process.exit(1);
-  }
-  
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
+import {
+  BasketStore,
+  getBasketViewerUrl,
+  resolveBasketStorePath,
+  resolveBasketViewerPort,
+  summarizeBasket,
+} from "./basket/store.js";
+import {
+  BASKET_MODEL_FIELD_GUIDE,
+  BasketContextInputSchema,
+  CandidateStatusSchema,
+  CartItemInputSchema,
+} from "./basket/schema.js";
+import { renderBasketViewerHtml } from "./basket/viewer-html.js";
+
+function setBaseHeaders(response: ServerResponse): void {
+  response.setHeader("Access-Control-Allow-Origin", "*");
+  response.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  response.setHeader("Cache-Control", "no-store");
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  setBaseHeaders(response);
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(`${JSON.stringify(body, null, 2)}\n`);
+}
+
+function sendHtml(response: ServerResponse, html: string): void {
+  setBaseHeaders(response);
+  response.statusCode = 200;
+  response.setHeader("Content-Type", "text/html; charset=utf-8");
+  response.end(html);
+}
+
+function sendError(response: ServerResponse, statusCode: number, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  sendJson(response, statusCode, { error: message });
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  return raw.length === 0 ? {} : JSON.parse(raw);
+}
+
+function itemIdFromPath(pathname: string, suffix = ""): string | null {
+  const prefix = "/api/items/";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
+    return null;
+  }
+  const withoutPrefix = pathname.slice(prefix.length);
+  const id = suffix.length > 0 ? withoutPrefix.slice(0, -suffix.length) : withoutPrefix;
+  return id.length > 0 ? decodeURIComponent(id) : null;
+}
+
+export async function startBasketViewer(options: {
+  port?: number;
+  store?: BasketStore;
+} = {}): Promise<Server> {
+  const port = options.port || resolveBasketViewerPort();
+  const store = options.store || new BasketStore(resolveBasketStorePath());
+  await store.load();
+
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method === "OPTIONS") {
+        setBaseHeaders(response);
+        response.statusCode = 204;
+        response.end();
+        return;
+      }
+
+      const url = new URL(request.url || "/", `http://${request.headers.host || "localhost"}`);
+      const pathname = url.pathname;
+
+      if (request.method === "GET" && (pathname === "/" || pathname === "/index.html")) {
+        sendHtml(response, renderBasketViewerHtml());
+        return;
+      }
+
+      if (request.method === "GET" && pathname === "/health") {
+        sendJson(response, 200, {
+          ok: true,
+          viewerUrl: getBasketViewerUrl(port),
+          storePath: store.path(),
+        });
+        return;
+      }
+
+      if (request.method === "GET" && pathname === "/api/model") {
+        sendJson(response, 200, {
+          fields: BASKET_MODEL_FIELD_GUIDE,
+        });
+        return;
+      }
+
+      if (request.method === "GET" && pathname === "/api/basket") {
+        sendJson(response, 200, summarizeBasket(await store.load()));
+        return;
+      }
+
+      if (request.method === "GET" && pathname === "/api/basket/raw") {
+        sendJson(response, 200, await store.load());
+        return;
+      }
+
+      if (request.method === "POST" && pathname === "/api/context") {
+        const body = BasketContextInputSchema.parse(await readJson(request));
+        sendJson(response, 200, summarizeBasket(await store.setContext(body)));
+        return;
+      }
+
+      if (request.method === "POST" && pathname === "/api/items") {
+        const body = await readJson(request);
+        const itemInput = CartItemInputSchema.parse(
+          typeof body === "object" && body != null && "item" in body
+            ? (body as { item: unknown }).item
+            : body
+        );
+        const result = await store.upsertItem(itemInput);
+        sendJson(response, result.created ? 201 : 200, {
+          item: result.item,
+          basket: summarizeBasket(result.basket),
+        });
+        return;
+      }
+
+      const statusItemId = itemIdFromPath(pathname, "/status");
+      if (request.method === "POST" && statusItemId != null) {
+        const body = await readJson(request);
+        const status = CandidateStatusSchema.parse((body as { status?: unknown }).status);
+        const item = await store.updateStatus(statusItemId, status);
+        if (item == null) {
+          sendJson(response, 404, { error: "Item not found" });
+          return;
+        }
+        sendJson(response, 200, { item, basket: summarizeBasket(await store.load()) });
+        return;
+      }
+
+      const deleteItemId = itemIdFromPath(pathname);
+      if (request.method === "DELETE" && deleteItemId != null) {
+        const removed = await store.removeItem(deleteItemId);
+        sendJson(response, removed ? 200 : 404, {
+          removed,
+          basket: summarizeBasket(await store.load()),
+        });
+        return;
+      }
+
+      if (request.method === "POST" && pathname === "/api/clear") {
+        const body = await readJson(request);
+        if ((body as { confirm?: boolean }).confirm !== true) {
+          sendJson(response, 400, { error: "confirm must be true" });
+          return;
+        }
+        sendJson(response, 200, summarizeBasket(await store.clear()));
+        return;
+      }
+
+      sendJson(response, 404, { error: "Not found" });
+    } catch (error) {
+      sendError(response, 400, error);
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const port = resolveBasketViewerPort();
+  startBasketViewer({ port })
+    .then(() => {
+      console.error(`Crossmint agent basket viewer: ${getBasketViewerUrl(port)}`);
+      console.error(`Basket store: ${resolveBasketStorePath()}`);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Adds an agent-facing pre-checkout basket with a neutral product model and a local HTTP web viewer to the Crossmint Checkout MCP server.

## What this adds

### Basket (MCP tools)
- `basket-set-context` — Set shopping/research context (title, intent, buyer, locale, currency, constraints)
- `basket-upsert-product` — Add or update a universal product candidate
- `basket-list-products` — List current candidates with viewer URL
- `basket-update-status` — Move through candidate → shortlisted → approved → ready_for_checkout → ordered → rejected
- `basket-remove-product` — Remove a candidate
- `basket-clear` — Clear the basket
- `basket-get-viewer` — Return viewer URL, store path, and HTTP API endpoints
- `basket-export-crossmint-line-items` — Export approved items as Crossmint-compatible line items

### Basket Viewer (HTTP server, port 4377)
- `GET /api/basket` — Compact basket summary
- `GET /api/basket/raw` — Full neutral basket JSON
- `POST /api/context` — Set context
- `POST /api/items` — Add/update product candidate
- `POST /api/items/:id/status` — Update status
- `DELETE /api/items/:id` — Remove candidate
- `POST /api/clear` — Clear basket with confirmation

### Key design decisions
- **Neutral product model** — Works with any e-commerce store (Amazon, Shopify, any URL)
- **Basket works without Crossmint credentials** — Designed for research and pre-purchase workflows where agents collect product candidates before user approves checkout
- **Local JSON persistence** — `.crossmint-agent-basket/basket.json`
- **Configurable** via `CROSSMINT_BASKET_PORT`, `CROSSMINT_BASKET_STORE_PATH`, `CROSSMINT_BASKET_PUBLIC_HOST`
- Added `crossmint-basket-viewer` binary to package.json

## Files changed

| File | Change |
|------|--------|
| `src/basket/schema.ts` | New — Zod schemas for basket, products, checkout state |
| `src/basket/store.ts` | New — BasketStore with atomic JSON persistence |
| `src/basket/viewer-html.ts` | New — Simple HTML viewer UI |
| `src/viewer.ts` | New — HTTP server for the basket viewer |
| `src/index.ts` | Modified — Added all basket MCP tools + textResponse helper |
| `README.md` | Modified — Added basket section with API docs and usage |
| `.env.template` | Modified — Added basket viewer env vars |
| `.gitignore` | Modified — Added .crossmint-agent-basket/ |
| `package.json` | Modified — Added basket-viewer binary and scripts |

## Related

This is the first step toward a multi-provider checkout system. A follow-up PR will add:
- Lobster Cash integration (virtual cards + crypto wallet)
- Multi-platform session management (login/register before checkout)
- Enhanced checkout readiness detection

See the [backlog](https://github.com/gordo-labs/mcp-crossmint-checkout/blob/feature/lobster-backlog/docs/BACKLOG.md) for the full roadmap.